### PR TITLE
Update EarthGravitationalModel.java

### DIFF
--- a/src/main/java/com/barbeaudev/geotools/referencing/operation/transform/EarthGravitationalModel.java
+++ b/src/main/java/com/barbeaudev/geotools/referencing/operation/transform/EarthGravitationalModel.java
@@ -300,10 +300,8 @@ public final class EarthGravitationalModel extends VerticalTransform {
      * @param latitude  The geodetic latitude, in decimal degrees.
      * @param height    The height above the ellipsoid in metres.
      * @return The value to add in order to get the height above the geoid (in metres).
-     * @throws Exception if the offset can't be computed for the specified coordinates.
      */
-    public double heightOffset(final double longitude, final double latitude, final double height)
-            throws Exception {
+    public synchronized double heightOffset(final double longitude, final double latitude, final double height) {
         /*
          * Note: no need to ensure that longitude is in [-180..+180°] range, because its value
          * is used only in trigonometric functions (sin / cos), which roll it as we would expect.


### PR DESCRIPTION
since cr, sr, s11, s12 are used as global Temporary buffer (Allocated once for ever for avoiding too many objects creation / destruction) the heightOffset method is not thread save and need to be synchronized (in order to avoid that multiple threads will manipulate data in the cr, sr, s11, s12 double[] at the same time)...

Also I don't see any reason what could cause an Exception to be thown - so I removed it from the signature